### PR TITLE
[fixed] GroovyDoc publication path in -javadoc artifact

### DIFF
--- a/src/main/assembly/javadoc.xml
+++ b/src/main/assembly/javadoc.xml
@@ -11,6 +11,7 @@
 	<fileSets>
 		<fileSet>
 			<directory>${project.build.directory}/site/apidocs/</directory>
+			<outputDirectory></outputDirectory>
 		</fileSet>
 	</fileSets>
 </assembly>


### PR DESCRIPTION
Summary
==============================

GroovyDoc was published in the `-javadoc` artifact at `./target/site/apidocs/`, when it should have been in the root of the javadoc JAR.

Checklist
==============================

Testing
-------------------------

n/a - no code changes

Documentation
-------------------------

n/a - no code changes
