### PR TITLE
[fixed] Added jenkins-releases <repository> block to each pom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+### Fixed
+
+* Added `<repositories>` section to all poms pointing to the Jenkins Release repository - so that Jenkins artifacts can be successfully located during builds.
+
 ## 2.0.1
 
 _Release Date: 2018-09-13_

--- a/examples/helper-script/pom.xml
+++ b/examples/helper-script/pom.xml
@@ -11,6 +11,14 @@
 
 	<description>Testing a Jenkinsfile and Helper Script with Spock</description>
 	
+	<repositories>
+		<repository>
+			<id>jenkins-releases</id>
+			<name>Jenkins Releases</name>
+			<url>http://repo.jenkins-ci.org/releases</url>
+		</repository>
+	</repositories>
+	
 	<properties>
 		
 		<groovy.core.version>2.4.11</groovy.core.version>

--- a/examples/shared-library/pom.xml
+++ b/examples/shared-library/pom.xml
@@ -9,7 +9,15 @@
 	<packaging>jar</packaging>
 	<version>0.0.0-SNAPSHOT</version> <!-- unused -->
 
-	<description>Testing a Jenkinsfile and Helper Script with Spock</description>
+	<description>Testing a Pipeline Shared Library with Spock</description>
+	
+	<repositories>
+		<repository>
+			<id>jenkins-releases</id>
+			<name>Jenkins Releases</name>
+			<url>http://repo.jenkins-ci.org/releases</url>
+		</repository>
+	</repositories>
 	
 	<properties>
 		

--- a/examples/whole-pipeline/pom.xml
+++ b/examples/whole-pipeline/pom.xml
@@ -11,6 +11,14 @@
 
 	<description>Testing a Jenkinsfile with Spock</description>
 	
+	<repositories>
+		<repository>
+			<id>jenkins-releases</id>
+			<name>Jenkins Releases</name>
+			<url>http://repo.jenkins-ci.org/releases</url>
+		</repository>
+	</repositories>
+	
 	<properties>
 		
 		<groovy.core.version>2.4.11</groovy.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,14 @@
 		<tag>HEAD</tag>
 	</scm>
 	
+	<repositories>
+		<repository>
+			<id>jenkins-releases</id>
+			<name>Jenkins Releases</name>
+			<url>http://repo.jenkins-ci.org/releases</url>
+		</repository>
+	</repositories>
+	
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>


### PR DESCRIPTION
Summary
==============================

This resolves issue #8.

Jenkins artifacts aren't actually in maven-central; they're in the Jenkins Releases repository.

This project's poms need the following XML in order to locate those artifacts:

```xml
<repositories>
	<repository>
		<id>jenkins-releases</id>
		<name>Jenkins Releases</name>
		<url>http://repo.jenkins-ci.org/releases</url>
	</repository>
</repositories>
```

Additional Details
==============================

Build runs in a vacuum now correctly download Jenkins artifacts from the Jenkins Releases repository, e.g.

```
docker run --rm -it -v "$(pwd)":/work --workdir /work mvn clean verify
...
Downloaded from jenkins-releases: http://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-core/2.102/jenkins-core-2.102.jar (11 MB at 521 kB/s)
...
```

Checklist
==============================

Testing
-------------------------

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [ ] ~I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions~ (N/A)

Documentation
-------------------------

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [x] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
