### PR TITLE
Make script loading classpath customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+* Make the resource path lookup customizable for `JenkinsPipelineSpecification#loadPipelineScriptForTest`. To define your own path set `JenkinsPipelineSpecification.scriptClassPath`.
+
 ### Fixed
 
 * Added `<repositories>` section to all poms pointing to the Jenkins Release repository - so that Jenkins artifacts can be successfully located during builds.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,31 @@ Depending on your parent pom, some of the `${jenkins.version}` properties may al
 
 If your code actually writes code against classes in any of these dependencies, remove the `<scope>test</scope>` entry for the corresponding block(s).
 
+Define Custom Classpath For Script Loading
+==============================
+
+When your project defined custom source sets you need to set the classpath for the loading of your scripts manually. E.g. when you want to load your custom pipeline script that is located in `test/resources` you can do:
+
+```groovy
+class PipelineTest extends JenkinsPipelineSpecification {
+
+    def setup() {
+       scriptClassPath = ["test/resources"] //Note that this is a collection and you can define multiple paths.
+    }
+
+    def "Some test"() {
+        def pipeline = loadPipelineScriptForTest("Jenkinsfile") // Will test/resources/Jenkinsfile
+        [...]
+    }
+}
+```
+
+The default paths are:
+* src/main/resources
+* src/test/resources
+* target/classes
+* target/test-classes
+
 Developer Guide
 ==============================
 

--- a/README.md
+++ b/README.md
@@ -99,31 +99,6 @@ Depending on your parent pom, some of the `${jenkins.version}` properties may al
 
 If your code actually writes code against classes in any of these dependencies, remove the `<scope>test</scope>` entry for the corresponding block(s).
 
-Define Custom Classpath For Script Loading
-==============================
-
-When your project defined custom source sets you need to set the classpath for the loading of your scripts manually. E.g. when you want to load your custom pipeline script that is located in `test/resources` you can do:
-
-```groovy
-class PipelineTest extends JenkinsPipelineSpecification {
-
-    def setup() {
-       scriptClassPath = ["test/resources"] //Note that this is a collection and you can define multiple paths.
-    }
-
-    def "Some test"() {
-        def pipeline = loadPipelineScriptForTest("Jenkinsfile") // Will test/resources/Jenkinsfile
-        [...]
-    }
-}
-```
-
-The default paths are:
-* src/main/resources
-* src/test/resources
-* target/classes
-* target/test-classes
-
 Developer Guide
 ==============================
 

--- a/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
+++ b/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
@@ -448,10 +448,10 @@ public abstract class JenkinsPipelineSpecification extends Specification {
 	 * {@link JenkinsPipelineSpecification#loadPipelineScriptForTest(java.lang.String)}. You can add or override this
 	 * path in case you specified custom source sets in your project.
 	 */
-	protected String[] scriptClassPath = ["src/main/resources", // if it's a main resource
-										  "src/test/resources", // if it's a test resource
-										  "target/classes", // if it's on the main classpath
-										  "target/test-classes"] // if it's on the test classpath
+	protected String[] script_class_path = ["src/main/resources", // if it's a main resource
+											"src/test/resources", // if it's a test resource
+											"target/classes", // if it's on the main classpath
+											"target/test-classes"] // if it's on the test classpath
 
 	/**
 	 * Add Spock Mock objects for each of the pipeline extensions to each of the _objects.
@@ -743,8 +743,8 @@ public abstract class JenkinsPipelineSpecification extends Specification {
 		return script
 	}
 
-	private String[] generateScriptClasspath(String resourcePath) {
-		return scriptClassPath.collect {path -> path + resourcePath }
+	protected String[] generateScriptClasspath(String resourcePath) {
+		return script_class_path.collect { path -> path + resourcePath }
 	}
 
 	/**

--- a/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
+++ b/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
@@ -50,6 +50,7 @@ import spock.lang.Specification
  * <li><a href="#mock-jenkins">Mock Jenkins</a></li>
  * <li><a href="#mock-pipeline-execution">Mock Pipeline Execution</a></li>
  * <li><a href="#metaprogramming">Metaprogramming</a></li>
+ * <li><a href="#custom-classpath">Define Custom Classpath For Script Loading</a></li>
  * </ol>
  * <a name="testing-groovy-functions"></a>
  * <h1>Testing Groovy Functions</h1>
@@ -347,12 +348,39 @@ then:
  * </p>
  * <pre><code>
 def methodMissing(String _name, _args) {
-	LOG.warn( "Called a misssing method: ${_name}(${_args.toString()})" )
+	LOG.warn( "Called a missing method: ${_name}(${_args.toString()})" )
 }
  * </code></pre>
- * <p>
+ * <p>	
  * simply cannot be enabled to call pipeline steps during tests. Avoid writing classes like that.
  * </p>
+ * 
+ * <a name="custom-classpath"></a>
+ * <h1>Define Custom Classpath For Script Loading</h1>
+ *
+ * When your project defined custom source sets you need to set the classpath for the loading of your scripts manually. 
+ * E.g. when you want to load your custom pipeline script that is located in `test/resources` you can do:
+ *
+ * <pre><code> 
+class PipelineTest extends JenkinsPipelineSpecification {*
+	def setup() {
+		scriptClassPath = ["test/resources"] //Note that this is a collection and you can define multiple paths.
+	}
+
+	def "Some test) {
+		def pipeline = loadPipelineScriptForTest("Jenkinsfile") // Will test/resources/Jenkinsfile
+		[...]
+	}
+}
+ * </code></pre>
+ *
+ * The default paths are:
+ * <ul>
+ * <li>src/main/resources</li>
+ * <li>src/test/resources</li>
+ * <li>target/classes</li>
+ * <li>target/test-classes</li>
+ * </ul>
  * 
  * @author awitt
  * @author mld-ger


### PR DESCRIPTION
Summary
==============================

In the setup of my project (which is actually a jenkins shared library project) I don't have the default source sets defined. This made it impossible to load a pipeline script outside of the defaults. This pull requests make the paths for loading a script customizable. 

This PR also resolved this issue: https://github.com/homeaway/jenkins-spock/issues/46

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [ x ] I have manually verified that my code changes do the right thing.
* [ x ] I have run the tests and verified that my changes do not introduce any regressions.
* [ - ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [ x ] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [ x ] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [ x ] I have read `CONTRIBUTING.md` and have followed its guidance.
