### PR TITLE
Emit more-specific exception when tests call a Groovy method w/ incorrect signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 
 * Added `<repositories>` section to all poms pointing to the Jenkins Release repository - so that Jenkins artifacts can be successfully located during builds.
+* Emit more-specific exception when tests call a Groovy method with an incorrect signature
 
 ## 2.0.1
 

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ClassToTestSpec.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ClassToTestSpec.groovy
@@ -23,6 +23,8 @@ import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
  * Given a regular Groovy class that tries to call pipeline steps (here {@link ClassToTest}),
  * verify that those calls can be mocked.
  * 
+ * Further verify that calls that can't be dispatched to a mock are handled correctly.
+ * 
  * @author awitt
  *
  */
@@ -39,5 +41,32 @@ public class ClassToTestSpec extends JenkinsPipelineSpecification {
 			1 * getPipelineMock( "echo" )("Hello from a [nodeType] node!")
 			1 * getPipelineMock( "echo" )("Goodbye from a [nodeType] node!")
 			1 * getPipelineMock( "echo" )("inside node")
+	}
+	
+	def "calling method with correct parameters"() {
+		given:
+			ClassToTest myVar = new ClassToTest()
+		when:
+			myVar.methodCall()
+		then:
+			1 * getPipelineMock( "echo")( "called methodCall" )
+	}
+	
+	def "calling method with incorrect parameters" () {
+		given:
+			ClassToTest myVar = new ClassToTest()
+		when:
+			myVar.methodCall( "incorrectParameter" )
+		then:
+			thrown MissingMethodException
+	}
+	
+	def "calling nonexistent method"() {
+		given:
+			ClassToTest myVar = new ClassToTest()
+		when:
+			myVar.nonexistentMethod()
+		then:
+			thrown IllegalStateException
 	}
 }

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ClassWithNoMethods.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ClassWithNoMethods.groovy
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2018 Expedia Group.
+ Copyright (c) 2019 Expedia Group.
  All rights reserved.  http://www.homeaway.com
  
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,20 +18,8 @@
 package com.homeaway.devtools.jenkins.testing.functions
 
 /**
- * A regular Groovy class that calls pipeline steps.
+ * A class with no methods.
  * @author awitt
  *
  */
-class ClassToTest {
-	public Map helloNode(String _label, Closure _body) {
-		return node( _label ) {
-			echo( "Hello from a [${_label}] node!" )
-			_body()
-			echo( "Goodbye from a [${_label}] node!" )
-		}
-	}
-	
-	public methodCall() {
-		echo( "called methodCall" )
-	}
-}
+class ClassWithNoMethods {}

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ClassWithNoMethodsSpec.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ClassWithNoMethodsSpec.groovy
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2018 Expedia Group.
+ Copyright (c) 2019 Expedia Group.
  All rights reserved.  http://www.homeaway.com
  
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,21 +17,22 @@
 
 package com.homeaway.devtools.jenkins.testing.functions
 
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+
 /**
- * A regular Groovy class that calls pipeline steps.
+ * Verify that classes without methods don't trip up the "failed to dispatch a call" logic
+ * 
  * @author awitt
  *
  */
-class ClassToTest {
-	public Map helloNode(String _label, Closure _body) {
-		return node( _label ) {
-			echo( "Hello from a [${_label}] node!" )
-			_body()
-			echo( "Goodbye from a [${_label}] node!" )
-		}
-	}
+public class ClassWithNoMethodsSpec extends JenkinsPipelineSpecification {
 	
-	public methodCall() {
-		echo( "called methodCall" )
+	def "calling nonexistent method"() {
+		given:
+			ClassToTest myVar = new ClassToTest()
+		when:
+			myVar.nonexistentMethod()
+		then:
+			thrown IllegalStateException
 	}
 }


### PR DESCRIPTION
Summary
==============================

Resolves Issue #48 as discussed.

Additional Information
==============================

To try this out and see it in action...

1. Check out the PR branch's code
2. `mvn clean install -DtrimStackTrace=false`
3. update your own project to use the newly-built SNAPSHOT version of `jenkins-spock`
4. Run your project's tests

You should see that the `methodCall` & similar calls with incorrect signatures produce a more traditional Groovy error message, and offer suggestions, eg (having done this for the [aforementioned example branch](https://github.com/homeaway/jenkins-spock/tree/issue-48/examples/shared-library)):

```groovy.lang.MissingMethodException:
No signature of method: otherClass.methodCall() is applicable for argument types: (java.lang.String) values: [incorrectParameter]
Possible solutions: methodCall()
	at com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification.addPipelineMocksToObjects_closure1$_closure13(JenkinsPipelineSpecification.groovy:539)
	at MyHelper.thing(MyHelper.groovy:5)
	at myStepFunction.call(myStepFunction.groovy:3)
	at myStepFunctionSpec.demonstrates incorrect method call(myStepFunctionSpec.groovy:13)
```

Checklist
==============================

Testing
-------------------------

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [x] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [x] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
