### PR TITLE
[updated] clarified the documentation for managing variables in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Updated
 	
 * Emit more-specific exception when tests call a Groovy method with an incorrect signature.
+* Clarified documentation for using "global" variables in tests.
 
 ### Added
 


### PR DESCRIPTION
Summary
==============================

The original documentation guided folks to thinking that _all_ variables in a Pipeline needed `explicitlyMockPipelineVariable(...)` when in fact only `GlobalVariables` worked with this approach, and regular variables could just be set in the `Binding` regularly.

 This has been a source of confusion for many people.

The documentation now makes this distinction up-front.

Additional Details
==============================

At least 3 issues arose from this ambiguity:

1. https://github.com/homeaway/jenkins-spock/issues/16
2. https://github.com/homeaway/jenkins-spock/issues/20
3. https://github.com/homeaway/jenkins-spock/issues/52

Checklist
==============================

Testing
-------------------------

N/A - no code changes

Documentation
-------------------------

N/A - no code changes
