### PR TITLE
[added] special-case the parallel() pipeline step and execute its closures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 * Make the resource path lookup customizable for `JenkinsPipelineSpecification#loadPipelineScriptForTest`. To define your own path set `JenkinsPipelineSpecification.scriptClassPath`.
 * The `maven-invoker-plugin` now runs some of the "working example" projects as integration tests.
+* The `parallel()` pipeline step is special-cased and will execute all of its closures during tests.
 
 ## 2.0.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,8 @@
 			<version>2.3</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<!-- 'parallel' step comes from workflow-cps -->
 
 	</dependencies>
 

--- a/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
+++ b/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
@@ -572,7 +572,18 @@ public abstract class JenkinsPipelineSpecification extends Specification {
 					 */
 					Object result = mocks.get( _name )( *_args )
 					
-					if( _args != null && _args.length >= 1 && _args[_args.length-1] instanceof Closure ) {
+					if( _name == "parallel" ) {
+						// special-case the parallel() step to execute all of its closures
+						// thanks, oswalpalash!
+						_args.each { Map _parallel_args ->
+							_parallel_args.each { _parallel_key, _parallel_value ->
+								if( _parallel_value instanceof Closure ) {
+									_parallel_value()
+								}
+							}
+						}
+						
+					} else 	if( _args != null && _args.length >= 1 && _args[_args.length-1] instanceof Closure ) {
 						// there was at least one argument, and the last argument was a Closure
 						// this almost certainly means that the user's trying to pass the closure to the function as a "body"
 						// they probably want it to execute right now.

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/ParallelClosureExecutionSpec.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/ParallelClosureExecutionSpec.groovy
@@ -1,0 +1,111 @@
+/*
+ Copyright (c) 2020 Expedia Group.
+ All rights reserved.  http://www.homeaway.com
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+   http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.homeaway.devtools.jenkins.testing;
+
+/**
+ * Verifies that the <code>parallel(...)</code> pipeline step is special-cased and
+ * that any closures passed to it as arguments are executed.
+ *
+ * @author awitt
+ *
+ */
+public class ParallelClosureExecutionSpec extends JenkinsPipelineSpecification {
+	
+	def "parallel() closures are executed when there is only one closure"() {
+		when:
+			parallel(
+				"stream1": {
+					echo( "stream1" )
+				}
+			)
+		then:
+			1 * getPipelineMock("echo")("stream1")
+	}
+	
+	def "parallel() closures are executed when there are multiple closures"() {
+		when:
+			parallel(
+				"stream1": {
+					echo( "stream1" )
+				},
+				"stream2": {
+					echo( "stream2" )
+				}
+			)
+		then:
+			1 * getPipelineMock("echo")("stream1")
+			1 * getPipelineMock("echo")("stream2")
+	}
+	
+	def "parallel() does not error when no closures are provided"() {
+		when:
+			parallel()
+		then:
+			0 * getPipelineMock("echo")(_)
+	}
+	
+	def "parallel() handles non-closure arguments"() {
+		when:
+			parallel(
+				failFast: true,
+				"stream1": {
+					echo( "stream1" )
+				},
+				"stream2": {
+					echo( "stream2" )
+				}
+			)
+		then:
+			1 * getPipelineMock("echo")("stream1")
+			1 * getPipelineMock("echo")("stream2")
+	}
+	
+	def "parallel() mock is called even when its closures are subsequently executed"() {
+		when:
+			parallel(
+				"stream1": {
+					echo( "stream1" )
+				},
+				"stream2": {
+					echo( "stream2" )
+				}
+			)
+		then:
+			1 * getPipelineMock("parallel")(_)
+	}
+	
+	def "parallel() arguments can be captured"() {
+		when:
+			parallel(
+				"stream1": {
+					echo( "stream1" )
+				},
+				"stream2": {
+					echo( "stream2" )
+				}
+			)
+		then:
+			1 * getPipelineMock("parallel")(_ as Map) >> { _parallel_args ->
+				Map parallel_map = _parallel_args[0]
+				assert parallel_map instanceof Map
+				assert parallel_map.size() == 2
+				assert parallel_map.containsKey( "stream1" )
+				assert parallel_map.containsKey( "stream2" )
+			}
+	}
+}

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/ParallelClosureExecutionSpec.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/ParallelClosureExecutionSpec.groovy
@@ -62,6 +62,7 @@ public class ParallelClosureExecutionSpec extends JenkinsPipelineSpecification {
 	def "parallel() handles non-closure arguments"() {
 		when:
 			parallel(
+				"failFast": true,
 				"stream 1" : {
 					echo( "hello 1" )
 				},

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/ParallelClosureExecutionSpec.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/ParallelClosureExecutionSpec.groovy
@@ -62,17 +62,16 @@ public class ParallelClosureExecutionSpec extends JenkinsPipelineSpecification {
 	def "parallel() handles non-closure arguments"() {
 		when:
 			parallel(
-				failFast: true,
-				"stream1": {
-					echo( "stream1" )
+				"stream 1" : {
+					echo( "hello 1" )
 				},
-				"stream2": {
-					echo( "stream2" )
+				"stream 2" : {
+					echo( "hello 2" )
 				}
 			)
 		then:
-			1 * getPipelineMock("echo")("stream1")
-			1 * getPipelineMock("echo")("stream2")
+			1 * getPipelineMock("echo")("hello 1")
+			1 * getPipelineMock("echo")("hello 2")
 	}
 	
 	def "parallel() mock is called even when its closures are subsequently executed"() {
@@ -102,6 +101,7 @@ public class ParallelClosureExecutionSpec extends JenkinsPipelineSpecification {
 		then:
 			1 * getPipelineMock("parallel")(_ as Map) >> { _parallel_args ->
 				Map parallel_map = _parallel_args[0]
+				
 				assert parallel_map instanceof Map
 				assert parallel_map.size() == 2
 				assert parallel_map.containsKey( "stream1" )


### PR DESCRIPTION
Summary
==============================

This resolves #51. The `parallel()` step previously was treated just like a normal step - mocked with nothing else.

Now, if `jenkins-spock` sees a `parallel(...)` pipeline step _it will execute each closure_.

Additional Details
==============================

The closures will be executed serially (this mirrors the actual implementation in Jenkins), in an undetermined order. The `failFast` argument will have no effect unless a developer explicitly stubs it to have an effect in their own test suite.

Checklist
==============================

Testing
-------------------------

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [x] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [x] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
