### PR TITLE
Update to use Reflections 0.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Updated
+
+* Updated Reflections to 0.9.12
+
 ## 2.1.1
 
 _Release Date: 2020-02-06_

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.11</version>
+			<version>0.9.12</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.lukehutch</groupId>


### PR DESCRIPTION
Summary
==============================

This updates to Reflections 0.9.12 which changes the transitive tree of the project

Additional Details
==============================

Previously with 0.9.11 Reflections bought in Guava 20. This marks the FindBugs dependency as optional. This can cause problems in other projects which rely in Guava 11/Grape/GMavenPlus all of which combine to result in `Error grabbing grapes`. 
Given this project already states it requires >= Java 1.8, updating https://github.com/ronmamo/reflections 0.9.12 which has support for Java 8 and has _removed_ the Guava 20 dependency solves this entire strange dependency hell problem transparently :-) 

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* N/A I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* N/A I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions


Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

N/A - no code changes