### PR TITLE
Update examples' jenkins-spock version to latest-released-version on release

### DIFF
--- a/.github/workflows/maven-branch-ci.yml
+++ b/.github/workflows/maven-branch-ci.yml
@@ -19,4 +19,7 @@ jobs:
     - name: Download Dependencies
       run: mvn --batch-mode dependency:go-offline -Pit
     - name: Build & Test with Maven
-      run: gawk && gawk --version
+      run: mvn verify 
+        --batch-mode
+        -P it
+        -D gpg.skip

--- a/.github/workflows/maven-branch-ci.yml
+++ b/.github/workflows/maven-branch-ci.yml
@@ -19,7 +19,4 @@ jobs:
     - name: Download Dependencies
       run: mvn --batch-mode dependency:go-offline -Pit
     - name: Build & Test with Maven
-      run: mvn verify 
-        --batch-mode
-        -P it
-        -D gpg.skip
+      run: gawk && gawk --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.1.3
+
+_Release Date: TBD_
+
+### Updated
+
+* `jenkins-spock` version used in examples and documentation is updated to the released version on release.
+
 ## 2.1.2
 
 _Release Date: 2020-03-12_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## 2.1.3
 
-_Release Date: TBD_
+_Release Date: 2020-05-29_
 
 ### Updated
 
-* `jenkins-spock` version used in examples and documentation is updated to the released version on release.
+* `jenkins-spock` version used in examples is updated to the released version on release.
 
 ## 2.1.2
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this library to `pom.xml` in the `test` scope:
 </dependency>
 ```
 
-Check the [CHANGELOG.md](CHANGELOG.md) to find the available versions.
+Check the [CHANGELOG.md](CHANGELOG.md) to find details about the available versions.
 
 Working Examples
 -------------------------

--- a/examples/helper-script/pom.xml
+++ b/examples/helper-script/pom.xml
@@ -36,7 +36,7 @@
 		<jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
 		<jenkins.workflow.step.version>2.10</jenkins.workflow.step.version>
 		
-		<jenkins-spock.version>2.0.1</jenkins-spock.version>
+		<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>
 		
 		<junit.version>4.12</junit.version>
 		

--- a/examples/helper-script/pom.xml
+++ b/examples/helper-script/pom.xml
@@ -36,7 +36,7 @@
 		<jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
 		<jenkins.workflow.step.version>2.10</jenkins.workflow.step.version>
 		
-		<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>
+		<jenkins-spock.version>2.0.1</jenkins-spock.version>
 		
 		<junit.version>4.12</junit.version>
 		

--- a/examples/shared-library/pom.xml
+++ b/examples/shared-library/pom.xml
@@ -36,7 +36,7 @@
 		<jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
 		<jenkins.workflow.step.version>2.10</jenkins.workflow.step.version>
 		
-		<jenkins-spock.version>2.0.1</jenkins-spock.version>
+		<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>
 		
 		<junit.version>4.12</junit.version>
 		

--- a/examples/shared-library/pom.xml
+++ b/examples/shared-library/pom.xml
@@ -36,7 +36,7 @@
 		<jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
 		<jenkins.workflow.step.version>2.10</jenkins.workflow.step.version>
 		
-		<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>
+		<jenkins-spock.version>2.0.1</jenkins-spock.version>
 		
 		<junit.version>4.12</junit.version>
 		

--- a/examples/whole-pipeline/pom.xml
+++ b/examples/whole-pipeline/pom.xml
@@ -36,7 +36,7 @@
 		<jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
 		<jenkins.workflow.step.version>2.10</jenkins.workflow.step.version>
 		
-		<jenkins-spock.version>2.0.1</jenkins-spock.version>
+		<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>
 		
 		<junit.version>4.12</junit.version>
 		

--- a/examples/whole-pipeline/pom.xml
+++ b/examples/whole-pipeline/pom.xml
@@ -36,7 +36,7 @@
 		<jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
 		<jenkins.workflow.step.version>2.10</jenkins.workflow.step.version>
 		
-		<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>
+		<jenkins-spock.version>2.0.1</jenkins-spock.version>
 		
 		<junit.version>4.12</junit.version>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,6 @@
 								<goal>checkin</goal>
 							</goals>
 							<configuration>
-								<includes>**/*.xml</includes>
 								<message>Updating examples to jenkins-spock:${project.version}</message>
 							</configuration>
 						</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.homeaway.devtools.jenkins</groupId>
 	<artifactId>jenkins-spock</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.1</version> <!-- http://semver.org -->
+	<version>2.1.3-SNAPSHOT</version> <!-- http://semver.org -->
 
 	<name>Jenkins pipeline support for Spock</name>
 	<description>Test Jenkins pipeline code with Spock</description>

--- a/pom.xml
+++ b/pom.xml
@@ -567,7 +567,7 @@
 							</goals>
 							<configuration>
 								<includes>**/*.xml</includes>
-								<excludes>**/target/*</excludes>
+								<excludes>**/target/</excludes>
 								<message>Updating examples to jenkins-spock:${project.version}</message>
 							</configuration>
 						</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -780,10 +780,29 @@
 							<arguments>
 								<argument>-c</argument>
 								<argument><![CDATA[
-									grep -lr "<jenkins-spock.version>" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>") }; { print }'
+									grep -lr "<jenkins-spock.version>" --include="*.xml" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>") }; { print }'
 								]]>
 								</argument>
 							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-scm-plugin</artifactId>
+				<version>${scm.pluginVersion}</version>
+				<executions>
+					<execution>
+						<id>checkin-updated-examples</id>
+						<goals>
+							<goal>add</goal>
+							<goal>checkin</goal>
+						</goals>
+						<configuration>
+							<includes>**/*.xml</includes>
+							<message>Updating examples to jenkins-spock:${project.version}</message>
 						</configuration>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,8 @@
 								<goal>checkin</goal>
 							</goals>
 							<configuration>
+								<includes>**/*.xml</includes>
+								<excludes>**/target/*</excludes>
 								<message>Updating examples to jenkins-spock:${project.version}</message>
 							</configuration>
 						</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
 							<configuration>
 								<includes>**/*.xml</includes>
 								<excludes>**/target/</excludes>
-								<message>Updating examples to jenkins-spock:${project.version}</message>
+								<message>[automated] Updating examples to jenkins-spock:${project.version}</message>
 							</configuration>
 						</execution>
 					</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.homeaway.devtools.jenkins</groupId>
 	<artifactId>jenkins-spock</artifactId>
 	<packaging>jar</packaging>
-	<version>2.1.3-SNAPSHOT</version> <!-- http://semver.org -->
+	<version>2.0.1</version> <!-- http://semver.org -->
 
 	<name>Jenkins pipeline support for Spock</name>
 	<description>Test Jenkins pipeline code with Spock</description>
@@ -77,6 +77,7 @@
 		<nexusStaging.pluginVersion>1.6.7</nexusStaging.pluginVersion>
 		<release.pluginVersion>2.5.3</release.pluginVersion>
 		<resources.pluginVersion>3.1.0</resources.pluginVersion>
+		<scm.pluginVersion>1.11.2</scm.pluginVersion>
 		<site.pluginVersion>3.7.1</site.pluginVersion>
 		<source.pluginVersion>2.2.1</source.pluginVersion>
 		<surefire.pluginVersion>2.22.0</surefire.pluginVersion>
@@ -771,16 +772,17 @@
 				<version>${exec.pluginVersion}</version>
 				<executions>
 					<execution>
-						<id>update-example-versions</id>
+						<id>update-maven-example-versions</id>
 						<goals>
 							<goal>exec</goal>
 						</goals>
 						<configuration>
+							<workingDirectory>${project.basedir}/examples</workingDirectory>
 							<executable>sh</executable>
 							<arguments>
 								<argument>-c</argument>
 								<argument><![CDATA[
-									grep -lr "<jenkins-spock.version>" --include="*.xml" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>") }; { print }'
+									grep -lr "<jenkins-spock.version>" --include="*.xml" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>${project.version}</jenkins-spock.version>") }; { print }'
 								]]>
 								</argument>
 							</arguments>

--- a/pom.xml
+++ b/pom.xml
@@ -543,12 +543,34 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
 					<version>${release.pluginVersion}</version>
+					<configuration>
+						<preparationGoals>clean exec:exec@update-maven-example-versions scm:add@checkin-updated-examples scm:checkin@checkin-updated-examples verify</preparationGoals>
+					</configuration>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
 					<version>${resources.pluginVersion}</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-scm-plugin</artifactId>
+					<version>${scm.pluginVersion}</version>
+					<executions>
+						<execution>
+							<id>checkin-updated-examples</id>
+							<goals>
+								<goal>add</goal>
+								<goal>checkin</goal>
+							</goals>
+							<configuration>
+								<includes>**/*.xml</includes>
+								<message>Updating examples to jenkins-spock:${project.version}</message>
+							</configuration>
+						</execution>
+					</executions>
 				</plugin>
 
 				<plugin>
@@ -687,6 +709,31 @@
 				</plugin>
 
 				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>exec-maven-plugin</artifactId>
+					<version>${exec.pluginVersion}</version>
+					<executions>
+						<execution>
+							<id>update-maven-example-versions</id>
+							<goals>
+								<goal>exec</goal>
+							</goals>
+							<configuration>
+								<workingDirectory>${project.basedir}/examples</workingDirectory>
+								<executable>sh</executable>
+								<arguments>
+									<argument>-c</argument>
+									<argument><![CDATA[
+										grep -lr "<jenkins-spock.version>" --include="*.xml" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>${project.version}</jenkins-spock.version>") }; { print }'
+									]]>
+									</argument>
+								</arguments>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
+
+				<plugin>
 					<groupId>org.sonatype.plugins</groupId>
 					<artifactId>nexus-staging-maven-plugin</artifactId>
 					<version>${nexusStaging.pluginVersion}</version>
@@ -765,51 +812,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
 			</plugin>
-			
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<version>${exec.pluginVersion}</version>
-				<executions>
-					<execution>
-						<id>update-maven-example-versions</id>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-						<configuration>
-							<workingDirectory>${project.basedir}/examples</workingDirectory>
-							<executable>sh</executable>
-							<arguments>
-								<argument>-c</argument>
-								<argument><![CDATA[
-									grep -lr "<jenkins-spock.version>" --include="*.xml" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>${project.version}</jenkins-spock.version>") }; { print }'
-								]]>
-								</argument>
-							</arguments>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-scm-plugin</artifactId>
-				<version>${scm.pluginVersion}</version>
-				<executions>
-					<execution>
-						<id>checkin-updated-examples</id>
-						<goals>
-							<goal>add</goal>
-							<goal>checkin</goal>
-						</goals>
-						<configuration>
-							<includes>**/*.xml</includes>
-							<message>Updating examples to jenkins-spock:${project.version}</message>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
 		<compiler.pluginVersion>3.8.0</compiler.pluginVersion>
 		<deploy.pluginVersion>2.8.2</deploy.pluginVersion>
 		<enforcer.pluginVersion>3.0.0-M2</enforcer.pluginVersion>
+		<exec.pluginVersion>1.6.0</exec.pluginVersion>
 		<gpg.pluginVersion>1.5</gpg.pluginVersion>
 		<install.pluginVersion>2.5.2</install.pluginVersion>
 		<invoker.pluginVersion>3.2.1</invoker.pluginVersion>
@@ -762,6 +763,30 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>${exec.pluginVersion}</version>
+				<executions>
+					<execution>
+						<id>update-example-versions</id>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>sh</executable>
+							<arguments>
+								<argument>-c</argument>
+								<argument><![CDATA[
+									grep -lr "<jenkins-spock.version>" . | xargs gawk -i inplace '{ gsub(/<jenkins-spock.version>[^<]+<\/jenkins-spock.version>/, "<jenkins-spock.version>2.1.3-SNAPSHOT</jenkins-spock.version>") }; { print }'
+								]]>
+								</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
Summary
==============================

Binds a `gawk`-based update of the "examples" projects' `jenkins-spock` dependencies to the maven `release:prepare` task.

This will cause any prepared release to include updates to the example projects, bumping their dependencies on `jenkins-spock` to the release version.

Additional Details
==============================

* `gawk` through the `exec-maven-plugin` does the in-place update of `<jenkins-spock.version>...</jenkins-spock.version>` in `*.xml` files in the `examples/` directory
* `maven-scm-plugin` adds and commits the changes as a separate commit, after the regular pom.xml version change

Checklist
==============================

Testing
-------------------------

N/A - no code changes

Documentation
-------------------------

N/A - no code changes