### PR TITLE
Update fast-classpath-scanner (2.8.1) to  classgraph (4.8.104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 *.pyc
 build.log
 **/*.versionsBackup
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
-* (nothing yet)
-
-## 2.1.5
-
-_Release Date: 2021-04-13_
-
 ### Updated
 * the deprecated `fast-classpath-scanner` to its latest form `classgraph`.
 * the deprecated `FastClasspathScanner` to its latest form `ClassGraph`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 
 ### Updated
-* the deprecated `fast-classpath-scanner` to its latest form `classgraph`.
-* the deprecated `FastClasspathScanner` to its latest form `ClassGraph`.
+
+* the deprecated `fast-classpath-scanner` dependency to its latest form `classgraph`.
+* the deprecated `FastClasspathScanner` class to its latest form `ClassGraph`.
 
 ## 2.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 * (nothing yet)
 
+## 2.1.5
+
+_Release Date: 2021-04-13_
+
+### Updated
+* the deprecated `fast-classpath-scanner` to its latest form `classgraph`.
+* the deprecated `FastClasspathScanner` to its latest form `ClassGraph`.
+
 ## 2.1.4
 
 _Release Date: 2020-06-01_

--- a/pom.xml
+++ b/pom.xml
@@ -276,11 +276,7 @@
 			<artifactId>reflections</artifactId>
 			<version>0.9.12</version>
 		</dependency>
-		<!--<dependency>-->
-		<!--<groupId>io.github.lukehutch</groupId>-->
-		<!--<artifactId>fast-classpath-scanner</artifactId>-->
-		<!--<version>3.1.13</version>-->
-		<!--</dependency>-->
+
 		<dependency>
 			<groupId>io.github.classgraph</groupId>
 			<artifactId>classgraph</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<developerConnection>scm:git:git@github.com:homeaway/jenkins-spock.git</developerConnection>
 		<tag>HEAD</tag>
 	</scm>
-	
+
 	<repositories>
 		<repository>
 			<id>jenkins-releases</id>
@@ -44,7 +44,7 @@
 			<url>http://repo.jenkins-ci.org/releases</url>
 		</repository>
 	</repositories>
-	
+
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
@@ -101,7 +101,7 @@
 		<!-- test settings -->
 		<slf4j.version>1.7.25</slf4j.version>
 		<junit.version>4.12</junit.version>
-		
+
 		<logback.configration>logback-test.xml</logback.configration>
 		<logdir>${project.build.directory}/log</logdir>
 		<test.loglevel>WARN</test.loglevel>
@@ -159,24 +159,24 @@
 										<cloneProjectsTo />
 										<streamLogs>true</streamLogs>
 									</configuration>
-								</execution>					
+								</execution>
 							</executions>
 						</plugin>
 					</plugins>
 				</pluginManagement>
-				
+
 				<plugins>
-					
+
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-resources-plugin</artifactId>
 					</plugin>
-					
+
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-invoker-plugin</artifactId>
 					</plugin>
-				
+
 				</plugins>
 			</build>
 		</profile>
@@ -276,10 +276,15 @@
 			<artifactId>reflections</artifactId>
 			<version>0.9.12</version>
 		</dependency>
+		<!--<dependency>-->
+		<!--<groupId>io.github.lukehutch</groupId>-->
+		<!--<artifactId>fast-classpath-scanner</artifactId>-->
+		<!--<version>3.1.13</version>-->
+		<!--</dependency>-->
 		<dependency>
-			<groupId>io.github.lukehutch</groupId>
-			<artifactId>fast-classpath-scanner</artifactId>
-			<version>2.8.2</version>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+			<version>4.8.104</version>
 		</dependency>
 
 		<dependency>
@@ -415,9 +420,9 @@
 			<version>2.3</version>
 			<scope>test</scope>
 		</dependency>
-		
+
 		<!-- 'parallel' step comes from workflow-cps -->
-		
+
 		<!-- 
 			for mocking the Jenkins singleton outside Spock
 			Only done to verify that IF that is done properly, THEN
@@ -550,7 +555,7 @@
 						<skip>true</skip>
 					</configuration>
 				</plugin>
-				
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
@@ -775,7 +780,7 @@
 				<groupId>org.codehaus.gmavenplus</groupId>
 				<artifactId>gmavenplus-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -790,12 +795,12 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
@@ -805,7 +810,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-install-plugin</artifactId>
@@ -815,7 +820,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
 			</plugin>
-			
+
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
 				<artifactId>nexus-staging-maven-plugin</artifactId>

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import io.github.classgraph.ClassGraph;
 
 /**
  * Search through classes in the entire classpath for Jenkins Pipeline extensions.
@@ -46,7 +46,11 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 
 		Set<Class<?>> classes = new HashSet<>();
 
-		List<String> classnames = new FastClasspathScanner(_package.orElse("") ).scan().getNamesOfAllStandardClasses();
+		List<String> classnames = new ClassGraph()
+				.enableAnnotationInfo()
+				.enableClassInfo()
+				.acceptPackages(_package.orElse(""))
+				.scan().getAllStandardClasses().getNames();
 
 		HashMap<String, Throwable> failures = new HashMap<>();
 
@@ -77,10 +81,10 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 				}
 			} else {
 				LOG.warn(
-					"Failed to get some classes of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
-					_supertype,
-					_package,
-					failures.keySet() );
+						"Failed to get some classes of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
+						_supertype,
+						_package,
+						failures.keySet() );
 			}
 		}
 
@@ -94,7 +98,11 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 
 		HashMap<String, Throwable> failures = new HashMap<>();
 
-		List<String> annotated_classnames = new FastClasspathScanner(_package.orElse("") ).scan().getNamesOfClassesWithAnnotation( _annotation );
+		List<String> annotated_classnames = new ClassGraph()
+				.enableAnnotationInfo()
+				.enableClassInfo()
+				.acceptPackages(_package.orElse(""))
+				.scan().getClassesWithAnnotation( _annotation.getName() ).getNames();
 
 		for(String classname: annotated_classnames) {
 
@@ -123,11 +131,11 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 				}
 			} else {
 				LOG.warn(
-					"Failed to get some classes annotated with [{}] of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
-					_annotation,
-					_supertype,
-					_package,
-					failures.keySet() );
+						"Failed to get some classes annotated with [{}] of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
+						_annotation,
+						_supertype,
+						_package,
+						failures.keySet() );
 			}
 		}
 

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
@@ -47,10 +47,10 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 		Set<Class<?>> classes = new HashSet<>();
 
 		List<String> classnames = new ClassGraph()
-				.enableAnnotationInfo()
-				.enableClassInfo()
-				.acceptPackages(_package.orElse(""))
-				.scan().getAllStandardClasses().getNames();
+			.enableAnnotationInfo()
+			.enableClassInfo()
+			.acceptPackages(_package.orElse(""))
+			.scan().getAllStandardClasses().getNames();
 
 		HashMap<String, Throwable> failures = new HashMap<>();
 

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
@@ -99,10 +99,10 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 		HashMap<String, Throwable> failures = new HashMap<>();
 
 		List<String> annotated_classnames = new ClassGraph()
-				.enableAnnotationInfo()
-				.enableClassInfo()
-				.acceptPackages(_package.orElse(""))
-				.scan().getClassesWithAnnotation( _annotation.getName() ).getNames();
+			.enableAnnotationInfo()
+			.enableClassInfo()
+			.acceptPackages(_package.orElse(""))
+			.scan().getClassesWithAnnotation( _annotation.getName() ).getNames();
 
 		for(String classname: annotated_classnames) {
 

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
@@ -81,10 +81,10 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 				}
 			} else {
 				LOG.warn(
-						"Failed to get some classes of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
-						_supertype,
-						_package,
-						failures.keySet() );
+					"Failed to get some classes of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
+					_supertype,
+					_package,
+					failures.keySet() );
 			}
 		}
 

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
@@ -131,11 +131,11 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 				}
 			} else {
 				LOG.warn(
-						"Failed to get some classes annotated with [{}] of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
-						_annotation,
-						_supertype,
-						_package,
-						failures.keySet() );
+					"Failed to get some classes annotated with [{}] of type [{}] in package [{}]. For detailed error messages, set the system property PipelineExtensionDetector.expandFailures=true. Failures: [{}]",
+					_annotation,
+					_supertype,
+					_package,
+					failures.keySet() );
 			}
 		}
 


### PR DESCRIPTION
Summary
==============================

`fast-classpath-scanner` has been deprecated; `classpath` is its successor. Replacing `fast-classpath-scanner` with `classgraph` caused a few code changes because the `classgraph` API has changed.

Additional Details
==============================

Before changing to `classpath`, with `fast-classpath-scanner` up to version `3.1.13`, unit tests written using `JenkinsPipelineSpecification` was throwing 
```
java.lang.OutOfMemoryError: GC Overhead Limit Exceeded
``` 
at [this line](https://github.com/ExpediaGroup/jenkins-spock/blob/935c4f2fc0d1fbe695cc6237597fc5a0cbe5e84c/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy#L1109).

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [ ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [ ] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
